### PR TITLE
Fixed method isValid()

### DIFF
--- a/sudoku/src/main/java/de/sfuhrm/sudoku/GameMatrix.java
+++ b/sudoku/src/main/java/de/sfuhrm/sudoku/GameMatrix.java
@@ -337,8 +337,8 @@ public class GameMatrix implements Cloneable {
             result &= findDuplicateBits(tmpData) == 0;
         }
 
-        for (int i = 0; i < BLOCK_SIZE && result; i++) {
-            for (int j = 0; j < BLOCK_SIZE && result; j++) {
+        for (int i = 0; i < SIZE && result; i += BLOCK_SIZE) {
+            for (int j = 0; j < SIZE && result; j += BLOCK_SIZE) {
                 block(i, j, tmpData);
                 result &= findDuplicateBits(tmpData) == 0;
             }


### PR DESCRIPTION
The previous version of isValid() checked all rows and columns correctly, but it checked only one block; therefore in some cases it returned true, even though a block contained two equal digits.
With this change isValid() should check all blocks.